### PR TITLE
Add task to estimate deploy cost and deploy on base mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,17 @@ OPTIONS:
 upgradeTokenSaleMarket: Upgrade a token sale market's logic to a new implementation.
 ```
 
-##
+## estimate deploy costs
+
+```sh
+Usage: hardhat [GLOBAL OPTIONS] estimateGasDeployDobBase [--input-config-file <STRING>]
+
+OPTIONS:
+
+  --input-config-file   Name of the input config to use (default: "dob_base.json")
+
+estimateGasDeployDobBase: A task to deploy base contracts for Dob enviroment
+```
 
 # Current Working Deploys
 

--- a/README.md
+++ b/README.md
@@ -322,3 +322,58 @@ estimateGasDeployDobBase: A task to deploy base contracts for Dob enviroment
   }
 }
 ```
+
+### Base Mainnet
+
+```json
+{
+  "storage": {
+    "address": "0xc2cda0C615Ac5aA8Cf2Af9B87c3C3c0ec5FefE4b",
+    "contract": "EternalStorage",
+    "owner": "0x6169C8D8070733B3866737089f891Aa0E9e608b0"
+  },
+  "poolMaster": {
+    "config": {
+      "address": "0x0c60E99E6B3C2FCc0E121eCF3cA5b7d74F5D010c",
+      "contract": "PoolMasterConfig",
+      "operational": "0x326C2610E0a97cB5e24a42059e2A2A0E41738b78",
+      "regression": {
+        "coef": 34813,
+        "intercept": 3217412,
+        "gasPrice": "100000000000"
+      },
+      "commission": 300
+    },
+    "deployer": {
+      "address": "0x1e0E82B5a1D4419f71812fF020a01bc11b022ec8",
+      "contract": "PoolMaster"
+    },
+    "owner": "0x6169C8D8070733B3866737089f891Aa0E9e608b0"
+  },
+  "poolLogic": [
+    {
+      "address": "0x12A45381a0c2dF275e76e812a380abDA65255500",
+      "versionNumber": "1"
+    }
+  ],
+  "treasury": {
+    "address": "0x4A0CD5b4E10fcaf9eC01BD42c730D8114f1157F8",
+    "ParticipationToken": {
+      "address": "0xcC76048288871825D68d8492cc3B7bafeB53BE83",
+      "name": "DobToken"
+    },
+    "owner": "0xB23d7b543f814a6E12B4cFc6b221a6826B058dBE",
+    "logicVersion": "1"
+  },
+  "tokenSaleMarket": {
+    "address": "0xFdf5028D05257234044aBbb43cbA7A1Cc4FB121B",
+    "contract": "LogicProxy",
+    "owner": "0x2de047cA4211b28AE2484BC1b9741044C2028261",
+    "logic": {
+      "address": "0xb714d43FF94e8893258Fe704Ed18a2a2f186d592",
+      "contract": "TokenSaleMarket"
+    },
+    "commission": 300
+  }
+}
+```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,6 +12,7 @@ import "./tasks/upgradePoolMaster"
 import "./tasks/deploydobToken"
 import "./tasks/upgradeTokenSaleMarket"
 import "./tasks/deployPools"
+import "./tasks/estimateGasDeployDobBase"
 
 
 require('hardhat-contract-sizer');
@@ -78,6 +79,11 @@ module.exports = {
       url: "https://api.avax-test.network/ext/bc/C/rpc",
       accounts:
         process.env.ACCOUNT_AVAX_FUJI?.split(",")
+    },
+    base: {
+      url: "https://mainnet.base.org/",
+      accounts:
+      process.env.ACCOUNT_BASE?.split(",")
     }
   },
   etherscan: {

--- a/tasks/configs/dob_base_base.json
+++ b/tasks/configs/dob_base_base.json
@@ -1,0 +1,28 @@
+{
+    "contracts": {
+        "storage": "EternalStorage",
+        "poolMasterDeployer": "PoolMaster",
+        "poolMasterConfig": "PoolMasterConfig",
+        "participationPool": "DistributionPool",
+        "tokenSaleMarket": "TokenSaleMarket",
+        "proxy": "LogicProxy"
+    },
+    "addressIds": {
+        "creator": 0,
+        "creatorExpected": "0x28f6273a228480E1e5e59aBC5d7Ecfb327A15927",
+        "storageOwner": "0x6169C8D8070733B3866737089f891Aa0E9e608b0",
+        "operational": "0x326C2610E0a97cB5e24a42059e2A2A0E41738b78",
+        "treasuryOwner": "0xB23d7b543f814a6E12B4cFc6b221a6826B058dBE",
+        "tokenSaleMarketOwner": "0x2de047cA4211b28AE2484BC1b9741044C2028261"
+    },
+    "regression": {
+        "coef": 34813,
+        "intercept": 3217412,
+        "gasPrice": "100000000000"
+    },
+    "commission": {
+        "poolMaster": 300,
+        "tokenSaleMarket": 300
+    },
+    "gasLimitMultiplier": 3
+}

--- a/tasks/estimateGasDeployDobBase.ts
+++ b/tasks/estimateGasDeployDobBase.ts
@@ -1,0 +1,126 @@
+import { task } from "hardhat/config";
+import fs from 'fs';
+import * as path from 'path';
+import "./subtasks/deployLogic";
+import "./subtasks/deployPoolMaster";
+import "./subtasks/deployStorage";
+import "./subtasks/deployTreasuryPool";
+import "./subtasks/deployTokenSaleMarket";
+import "./subtasks/transferOnwership";
+import { checkCreatorAddress } from "./subtasks/utils/deploy-utils";
+import { estimateContractGas} from "./subtasks/utils/contract-utils";
+import { BigNumber } from "ethers";
+
+
+task("estimateGasDeployDobBase", "A task to estimate the deploy cost of base contracts for Dob enviroment")
+    .addOptionalParam("inputConfigFile", "Name of the input config to use", "dob_base.json")
+    .setAction(async (taskArgs, hre) =>{
+        const now = new Date();
+        let inputConfigFile = path.join(
+            __dirname, "configs", 
+            taskArgs.inputConfigFile);
+        let inData = JSON.parse(fs.readFileSync(
+            path.join(inputConfigFile), 'utf8'));
+        const accounts = await hre.ethers.getSigners();
+        if (!checkCreatorAddress(accounts,inData)){
+            console.log("trowing error")
+            throw new Error("creator address does not match")
+        }
+        const avg_gas_price = BigNumber.from("70000000")
+        console.log("avg gasPrice -> \t", hre.ethers.utils.formatEther(avg_gas_price.toString()))
+        const limit_gas_price = avg_gas_price.mul(BigNumber.from(2))
+        console.log("limit gasPrice -> \t", hre.ethers.utils.formatEther(limit_gas_price.toString()))
+        console.log("::: estimate (gasUsed * gasPrice) to deploy each contract :::")
+        let storage: BigNumber = await estimateContractGas(
+            hre, inData["contracts"]["storage"], {}, false, {}, 
+            [], 
+            accounts[inData["addressIds"]["creator"]]);
+        storage = storage.mul(limit_gas_price)
+        
+        console.log("storage -> \t\t\t", hre.ethers.utils.formatEther(storage.toString()))
+
+        let poolMasterConfigLogic = await estimateContractGas(
+            hre, inData["contracts"]["poolMasterConfig"], {}, false, {}, 
+            [
+                hre.ethers.constants.AddressZero
+            ],
+            accounts[inData["addressIds"]["creator"]]);
+        let poolMasterConfigProxy = await estimateContractGas(
+            hre, inData["contracts"]["proxy"], {}, false, {}, 
+            [
+                hre.ethers.constants.AddressZero, "Pool.master.config.proxy"
+            ],
+            accounts[inData["addressIds"]["creator"]]);
+        poolMasterConfigLogic = poolMasterConfigLogic.mul(limit_gas_price)
+        poolMasterConfigProxy = poolMasterConfigProxy.mul(limit_gas_price)
+        console.log("pool master config logic -> \t", hre.ethers.utils.formatEther(poolMasterConfigLogic.toString()))
+        console.log("pool master config proxy -> \t", hre.ethers.utils.formatEther(poolMasterConfigProxy.toString()))
+
+        let poolMasterDeployerLogic = await estimateContractGas(
+            hre, inData["contracts"]["poolMasterDeployer"], {}, false, {}, 
+            [
+                hre.ethers.constants.AddressZero
+            ],
+            accounts[inData["addressIds"]["creator"]]);
+        let poolMasterDeployerProxy = await estimateContractGas(
+            hre, inData["contracts"]["proxy"], {}, false, {}, 
+            [
+                hre.ethers.constants.AddressZero, "Pool.master.deployer.proxy"
+            ],
+            accounts[inData["addressIds"]["creator"]]);
+        poolMasterDeployerLogic = poolMasterDeployerLogic.mul(limit_gas_price)
+        poolMasterDeployerProxy = poolMasterDeployerProxy.mul(limit_gas_price)
+        console.log("pool master deployer logic -> \t", hre.ethers.utils.formatEther(poolMasterConfigLogic.toString()))
+        console.log("pool master deployer proxy -> \t", hre.ethers.utils.formatEther(poolMasterConfigProxy.toString()))
+
+        let logic = await estimateContractGas(
+            hre,inData["contracts"]["participationPool"], {}, false, {}, 
+            [
+                hre.ethers.constants.AddressZero
+            ],
+            accounts[inData["addressIds"]["creator"]]);
+
+        logic = logic.mul(limit_gas_price)
+        console.log("participation pool logic -> \t", hre.ethers.utils.formatEther(logic.toString()))
+
+
+        console.log("treasury pool  -> \t\t cannot estimate")
+
+        let tokenSaleMarketLogic = await estimateContractGas(
+            hre, inData["contracts"]["tokenSaleMarket"], {}, false, {},
+            [
+                hre.ethers.constants.AddressZero,
+                // {gasPrice: "7000000000"}
+            ],
+            accounts[inData["addressIds"]["creator"]]);
+        let proxy = await estimateContractGas(
+            hre, inData["contracts"]["proxy"], {}, false, {},
+            [
+                hre.ethers.constants.AddressZero,
+                "TSMProxy",
+                // {gasPrice: "7000000000"}
+            ],
+            accounts[inData["addressIds"]["creator"]]
+        )
+        tokenSaleMarketLogic = tokenSaleMarketLogic.mul(limit_gas_price)
+        proxy = proxy.mul(limit_gas_price)
+        console.log("token sale market logic -> \t", hre.ethers.utils.formatEther(tokenSaleMarketLogic.toString()))
+        console.log("token sale market  proxy -> \t", hre.ethers.utils.formatEther(proxy.toString()))
+        console.log("---------------------")
+        let total = storage.add(poolMasterConfigLogic)
+            .add(poolMasterConfigProxy).add(poolMasterDeployerLogic)
+            .add(poolMasterDeployerProxy).add(logic).add(tokenSaleMarketLogic)
+            .add(proxy)
+
+        console.log("total -> \t\t\t", hre.ethers.utils.formatEther(total.toString()))
+
+        // await hre.run("deployPoolMaster", argFiles)
+        // await new Promise(f => setTimeout(f, 1000));
+        // await hre.run("deployLogic", argFiles)
+        // await new Promise(f => setTimeout(f, 1000));
+        // await hre.run("deployTreasuryPool", argFiles)
+        // await new Promise(f => setTimeout(f, 1000));
+        // await hre.run("deployTokenSaleMarket", argFiles)
+        // await new Promise(f => setTimeout(f, 1000));
+        // await hre.run("transferOwnership", argFiles)
+    })

--- a/tasks/subtasks/deployTokenSaleMarket.ts
+++ b/tasks/subtasks/deployTokenSaleMarket.ts
@@ -27,19 +27,21 @@ subtask("deployTokenSaleMarket", "Deploy a new tokenSaleMarket")
             hre, inData["contracts"]["tokenSaleMarket"], {}, false, {},
             [
                 outData["storage"]["address"],
-                {gasPrice: gasPrice}
+                // {gasPrice: gasPrice}
             ],
             accounts[inData["addressIds"]["creator"]]);
+        console.log("tokenSaleMarketLogic.address", tokenSaleMarketLogic.address)
         console.log("deploy tokenSaleMarketProxy")
         let proxy = await deployerContract(
             hre, inData["contracts"]["proxy"], {}, false, {},
             [
                 outData["storage"]["address"],
                 "TSMProxy",
-                {gasPrice: gasPrice}
+                // {gasPrice: gasPrice}
             ],
             accounts[inData["addressIds"]["creator"]]
         )
+        console.log("proxy.addres", proxy.address)
         console.log("done deploys")
         let txData;
         let resData;
@@ -53,10 +55,10 @@ subtask("deployTokenSaleMarket", "Deploy a new tokenSaleMarket")
         txData = await storage.connect(accounts[inData["addressIds"]["creator"]])
             .functions.grantUserRole(
                 tokenSaleMarketLogic.address, 
-                {
-                    gasLimit: estimated.mul(gasLimitMultiplier).toString(),
-                    gasPrice: gasPrice
-                }
+                // {
+                //     gasLimit: estimated.mul(gasLimitMultiplier).toString(),
+                //     gasPrice: gasPrice
+                // }
             );
         resData = await txData.wait();
         console.log("->grant role to proxy")
@@ -65,10 +67,10 @@ subtask("deployTokenSaleMarket", "Deploy a new tokenSaleMarket")
         txData = await storage.connect(accounts[inData["addressIds"]["creator"]])
             .functions.grantUserRole(
                 proxy.address, 
-                {
-                    gasLimit: estimated.mul(gasLimitMultiplier).toString(),
-                    gasPrice: gasPrice
-                }
+                // {
+                //     gasLimit: estimated.mul(gasLimitMultiplier).toString(),
+                //     gasPrice: gasPrice
+                // }
             );
         resData = await txData.wait();
         console.log("->initialize proxy")
@@ -77,10 +79,10 @@ subtask("deployTokenSaleMarket", "Deploy a new tokenSaleMarket")
         txData = await proxy.connect(accounts[inData["addressIds"]["creator"]])
             .functions.initLogic(
                 tokenSaleMarketLogic.address, 
-                {
-                    gasLimit: estimated.mul(gasLimitMultiplier).toString(),
-                    gasPrice: gasPrice
-                }
+                // {
+                //     gasLimit: estimated.mul(gasLimitMultiplier).toString(),
+                //     gasPrice: gasPrice
+                // }
             );
         resData = await txData.wait();
         console.log("->attach abi")
@@ -94,10 +96,10 @@ subtask("deployTokenSaleMarket", "Deploy a new tokenSaleMarket")
             .functions.initialize(
                 inData["addressIds"]["tokenSaleMarketOwner"],
                 inData["commission"]["tokenSaleMarket"]),
-                {
-                    gasLimit: estimated.mul(gasLimitMultiplier).toString(),
-                    gasPrice: gasPrice
-                }
+                // {
+                //     gasLimit: estimated.mul(gasLimitMultiplier).toString(),
+                //     gasPrice: gasPrice
+                // }
         resData = await txData.wait();
 
         outData["tokenSaleMarket"] = {

--- a/tasks/subtasks/utils/contract-utils.ts
+++ b/tasks/subtasks/utils/contract-utils.ts
@@ -25,6 +25,38 @@ export async function deployerContract(hre, nameContract: string, libraries = {}
     return contract;
 }
 
+
+// return: Promise<BigNumber>
+// hre: Hardhat Runtime Environment (HRE)
+// signer: Signer
+export async function estimateContractGas(hre, nameContract: string, libraries = {},
+    upgradable: boolean = false, upgradeOptions = {}, deployArgs: any[] = [],
+    signer) {
+    var factoryOptions: object = {};
+    if (signer === undefined) {
+        factoryOptions = { libraries: libraries }
+    } else {
+        factoryOptions = { libraries: libraries, signer: signer };
+    }
+
+    const ContracT = await hre.ethers.getContractFactory(
+        nameContract, factoryOptions);
+    
+    let gasEstimate;
+    if (upgradable) {
+        // For upgradable contract deployment, simulate a proxy deploy and estimate gas
+        gasEstimate = await hre.upgrades.estimateGas.deployProxy(ContracT, upgradeOptions);
+    } else {
+        // For normal contracts, estimate the gas for deploying the contract
+        gasEstimate = await ContracT.signer.estimateGas(
+            ContracT.getDeployTransaction(...deployArgs)
+        );
+    }
+
+    return gasEstimate;
+}
+
+
 // return: Promise<Contract>
 // hre: Hardhat Runtime Environment (HRE)
 export async function upgradeContract(hre, nameContract: string, libraries = {},


### PR DESCRIPTION
* Add a new task to estimate the deploy cost of all core contracts in dob.
* Add the records of a new deploy on Base Mainnet.
* Disable the fixed gasLimit and gasPrice during the deploy and configuration of tokenSaleMarket.